### PR TITLE
Find the relative root path by using the new option variable rename.root_markers

### DIFF
--- a/lua/java.lua
+++ b/lua/java.lua
@@ -1,5 +1,6 @@
 local java = {}
 
+local options = require("java.options")
 local rename = require("java.rename")
 local snippets = require("java.snippets")
 
@@ -7,7 +8,9 @@ function java.setup(opts)
     if opts == nil then
         opts = {}
     end
+
     
+    options.setup(opts)
     rename.setup(opts.rename)
     snippets.setup(opts.snippets)
 end

--- a/lua/java/options.lua
+++ b/lua/java/options.lua
@@ -1,0 +1,24 @@
+local java_options = {}
+
+local options = nil
+
+function java_options.setup(opts)
+    if opts == nil then
+        opts = {}
+    end
+
+    if opts.root_markers == nil then
+        opts.root_markers = {
+          "main/java/",
+          "test/java/"
+        }
+    end
+
+    options = opts
+end
+
+function java_options.get_java_options()
+    return options
+end
+
+return java_options

--- a/lua/java/rename.lua
+++ b/lua/java/rename.lua
@@ -18,15 +18,12 @@ local options = require("java.rename.options")
 -- @param path the full path of the package
 -- @return the package_name in dot-seperated format
 local function get_package_name(path)
-    -- find the relative root path by splitting the array (should always be "main/java" or "test/java")
-    local parts = utils.split(path, "main/java/")
+    local root_markers = options.get_rename_options().root_markers
 
-    -- if main/java could not be found, try test/java
-    if #parts <= 1 then
-        parts = utils.split(path, "test/java/")
-    end
+    -- find the relative root path by splitting the array, which is defined by options.root_markers
+    local parts = utils.split_with_patterns(path, root_markers)
 
-    -- if main/java or test/java could not be found, cancel
+    -- if any of the root markers could not be found, cancel
     if #parts <= 1 then
         return nil
     end

--- a/lua/java/rename.lua
+++ b/lua/java/rename.lua
@@ -10,7 +10,8 @@ local regex_import_declaration = require("java.rename.regex.import-declaration")
 local regex_symbol_usage = require("java.rename.regex.symbol-usage")
 local regex_fix_import_declaration = require("java.rename.regex.fix-import-declaration")
 
-local options = require("java.rename.options")
+local rename_options = require("java.rename.options")
+local options = require("java.options")
 
 
 -- function that returns the package name of a given path
@@ -18,7 +19,7 @@ local options = require("java.rename.options")
 -- @param path the full path of the package
 -- @return the package_name in dot-seperated format
 local function get_package_name(path)
-    local root_markers = options.get_rename_options().root_markers
+    local root_markers = options.get_java_options().root_markers
 
     -- find the relative root path by splitting the array, which is defined by options.root_markers
     local parts = utils.split_with_patterns(path, root_markers)
@@ -78,7 +79,7 @@ function java_rename.on_rename_file(old_name, new_name)
     local old_class_path = old_package_name .. "." .. old_class_name
     local new_class_path = new_package_name .. "." .. new_class_name
 
-    local opts = options.get_rename_options()
+    local opts = rename_options.get_rename_options()
 
     -- replace class name declaration in class file
     local state = buffer.open(new_name)
@@ -121,9 +122,9 @@ end
 
 -- setup the java rename plugin with options, see README.md for further information
 function java_rename.setup(opts)
-    options.setup(opts)
+    rename_options.setup(opts)
 
-    local opts = options.get_rename_options()
+    local opts = rename_options.get_rename_options()
 
     if not opts.enable then
         return

--- a/lua/java/rename/options.lua
+++ b/lua/java/rename/options.lua
@@ -9,10 +9,6 @@ function rename_options.setup(opts)
             enable = true,
             nvimtree = true,
             write_and_close = false,
-            root_markers = {
-              "main/java/",
-              "test/java/"
-            }
         }
     end
 
@@ -28,12 +24,6 @@ function rename_options.setup(opts)
         opts.write_and_close = false
     end
 
-    if opts.root_markers == nil then
-        opts.root_markers = {
-          "main/java/",
-          "test/java/"
-        }
-    end
 
     options = opts
 end

--- a/lua/java/rename/options.lua
+++ b/lua/java/rename/options.lua
@@ -8,7 +8,11 @@ function rename_options.setup(opts)
         opts = {
             enable = true,
             nvimtree = true,
-            write_and_close = false
+            write_and_close = false,
+            root_markers = {
+              "main/java/",
+              "test/java/"
+            }
         }
     end
 
@@ -22,6 +26,13 @@ function rename_options.setup(opts)
 
     if opts.write_and_close == nil then
         opts.write_and_close = false
+    end
+
+    if opts.root_markers == nil then
+        opts.root_markers = {
+          "main/java/",
+          "test/java/"
+        }
     end
 
     options = opts

--- a/lua/java/rename/utils.lua
+++ b/lua/java/rename/utils.lua
@@ -20,6 +20,20 @@ function utils.split(pString, pPattern)
    return Table
 end
 
+function utils.split_with_patterns(pString, pPatternTable)
+   local Table = {}  -- NOTE: use {n = 0} in Lua-5.0
+
+   for _, pattern in ipairs(pPatternTable) do
+       Table = utils.split(pString, pattern)
+
+       if #Table > 1 then
+         break
+       end
+       -- The pattern could not be found
+   end
+   return Table
+end
+
 -- check if a path is a directory
 function utils.is_dir(path)
     local f = io.open(path, "r")

--- a/lua/java/snippets/init-file.lua
+++ b/lua/java/snippets/init-file.lua
@@ -4,7 +4,7 @@ local ls = require("luasnip")
 local fmt = require("luasnip.extras.fmt").fmt
 local i = ls.insert_node
 local f = ls.function_node
-local utils = require("user.utils")
+local utils = require("java.rename.utils")
 
 local function getShiftWidth()
     return vim.api.nvim_buf_get_option(0, "shiftwidth")

--- a/lua/java/snippets/init-file.lua
+++ b/lua/java/snippets/init-file.lua
@@ -5,6 +5,7 @@ local fmt = require("luasnip.extras.fmt").fmt
 local i = ls.insert_node
 local f = ls.function_node
 local utils = require("java.rename.utils")
+local options = require("java.rename.options")
 
 local function getShiftWidth()
     return vim.api.nvim_buf_get_option(0, "shiftwidth")
@@ -12,14 +13,11 @@ end
 
 local function getPackageName()
     local folder = vim.fn.expand("%:h")
+    local root_markers = options.get_rename_options().root_markers
 
-    local splitted = utils.split(folder, "main/java/")
+    local splitted = utils.split_with_patterns(folder, root_markers)
 
-    -- if main/java could not be found, try test/java
-    if #splitted <= 1 then
-        splitted = utils.split(folder, "test/java/")
-    end
-
+    -- if any of the root markers could not be found, cancel
     if #splitted <= 1 then
         return ""
     end

--- a/lua/java/snippets/init-file.lua
+++ b/lua/java/snippets/init-file.lua
@@ -5,7 +5,7 @@ local fmt = require("luasnip.extras.fmt").fmt
 local i = ls.insert_node
 local f = ls.function_node
 local utils = require("java.rename.utils")
-local options = require("java.rename.options")
+local options = require("java.options")
 
 local function getShiftWidth()
     return vim.api.nvim_buf_get_option(0, "shiftwidth")
@@ -13,7 +13,7 @@ end
 
 local function getPackageName()
     local folder = vim.fn.expand("%:h")
-    local root_markers = options.get_rename_options().root_markers
+    local root_markers = options.get_java_options().root_markers
 
     local splitted = utils.split_with_patterns(folder, root_markers)
 


### PR DESCRIPTION
The project structure of some of the older projects I am working on do not start with "main/java" or "test/java".
For these cases I need the possibility to define my own "root marker"

With this pull request, the user can set the following option to determine where the root of the project is :
``` lua
rename = {
  root_markers = {
    "main/java/",
    "test/java/"
  },
},
```
Currently it only works with folders, but I can try to customize it so that it also works with files or that it determines the root via the LSP.